### PR TITLE
Rename project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ae-framework [![Build Status](https://travis-ci.org/wfmu/ae-framework.svg?branch=master)](https://travis-ci.org/wfmu/ae-framework)
+# ae-utils [![Build Status](https://travis-ci.org/wfmu/ae-utils.svg?branch=master)](https://travis-ci.org/wfmu/ae-utils)
 
 ## Getting Started
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.network "private_network", ip: "192.168.13.38"
-  config.vm.synced_folder ".", "/mnt/ae-framework/"
+  config.vm.synced_folder ".", "/mnt/ae-utils/"
 
   config.vm.provision "ansible" do |ansible|
     ansible.limit = "vagrant"

--- a/ansible/inventory/development
+++ b/ansible/inventory/development
@@ -3,6 +3,6 @@ vagrant ansible_ssh_host=192.168.13.38 ansible_ssh_user=vagrant
 vagrant
 
 [appserver:vars]
-root=/mnt/ae-framework
+root=/mnt/ae-utils
 serverName=api.dev
 mysqlRootPass=12345

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,17 @@
 {
-  "name": "wfmu/ae-framework",
+  "name": "wfmu/ae-utils",
   "require": {
     "phpunit/dbunit": ">=1.2",
     "squizlabs/php_codesniffer": "2.*"
   },
   "autoload": {
     "psr-4": {
-      "AEFramework\\": "src/"
+      "AEUtils\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "AEFramework\\test\\": "test/"
+      "AEUtils\\test\\": "test/"
     }
   }
 }

--- a/src/Database.php
+++ b/src/Database.php
@@ -1,5 +1,5 @@
 <?php
-namespace AEFramework;
+namespace AEUtils;
 use \mysqli;
 
 class Database implements DatabaseInterface {

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace AEFramework;
+namespace AEUtils;
 
 Interface DatabaseInterface {
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1,5 +1,5 @@
 <?php
-namespace AEFramework;
+namespace AEUtils;
 
 class Helpers {
   // add a utility function for plucking data

--- a/src/JsonResHandler.php
+++ b/src/JsonResHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace AEFramework;
+namespace AEUtils;
 
 Class JsonResHandler {
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -1,7 +1,7 @@
 <?php
-namespace AEFramework;
+namespace AEUtils;
 
-use \AEFramework\JsonResHandler;
+use \AEUtils\JsonResHandler;
 
 class Router Implements RouterInterface {
 

--- a/src/RouterInterface.php
+++ b/src/RouterInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace AEFramework;
+namespace AEUtils;
 
 Interface RouterInterface {
 

--- a/src/collections/BaseCollection.php
+++ b/src/collections/BaseCollection.php
@@ -1,9 +1,9 @@
 <?php
-namespace AEFramework\collections;
+namespace AEUtils\collections;
 
-use \AEFramework\Database;
-use \AEFramework\models\BaseModel;
-use \AEFramework\Helpers;
+use \AEUtils\Database;
+use \AEUtils\models\BaseModel;
+use \AEUtils\Helpers;
 
 class BaseCollection {
 

--- a/src/models/BaseModel.php
+++ b/src/models/BaseModel.php
@@ -1,8 +1,8 @@
 <?php
-namespace AEFramework\models;
+namespace AEUtils\models;
 
 use Exception;
-use \AEFramework\Database;
+use \AEUtils\Database;
 
 class BaseModel {
 

--- a/src/routes/BaseJsonDeleteRoute.php
+++ b/src/routes/BaseJsonDeleteRoute.php
@@ -1,7 +1,7 @@
 <?php
-namespace AEFramework\routes;
+namespace AEUtils\routes;
 
-use \AEFramework\JsonResHandler;
+use \AEUtils\JsonResHandler;
 use Exception;
 
 class BaseJsonDeleteRoute extends BaseJsonRoute {

--- a/src/routes/BaseJsonGetAllRoute.php
+++ b/src/routes/BaseJsonGetAllRoute.php
@@ -1,8 +1,8 @@
 <?php
-namespace AEFramework\routes;
+namespace AEUtils\routes;
 
-use \AEFramework\JsonResHandler;
-use \AEFramework\collections\BaseCollection;
+use \AEUtils\JsonResHandler;
+use \AEUtils\collections\BaseCollection;
 use Exception;
 
 class BaseJsonGetAllRoute extends BaseJsonRoute {

--- a/src/routes/BaseJsonGetOneRoute.php
+++ b/src/routes/BaseJsonGetOneRoute.php
@@ -1,7 +1,7 @@
 <?php
-namespace AEFramework\routes;
+namespace AEUtils\routes;
 
-use \AEFramework\JsonResHandler;
+use \AEUtils\JsonResHandler;
 use Exception;
 
 class BaseJsonGetOneRoute extends BaseJsonRoute {

--- a/src/routes/BaseJsonPostRoute.php
+++ b/src/routes/BaseJsonPostRoute.php
@@ -1,7 +1,7 @@
 <?php
-namespace AEFramework\routes;
+namespace AEUtils\routes;
 
-use \AEFramework\JsonResHandler;
+use \AEUtils\JsonResHandler;
 
 class BaseJsonPostRoute extends BaseJsonRoute {
 

--- a/src/routes/BaseJsonPutRoute.php
+++ b/src/routes/BaseJsonPutRoute.php
@@ -1,7 +1,7 @@
 <?php
-namespace AEFramework\routes;
+namespace AEUtils\routes;
 
-use \AEFramework\JsonResHandler;
+use \AEUtils\JsonResHandler;
 use Exception;
 
 class BaseJsonPutRoute extends BaseJsonRoute {

--- a/src/routes/BaseJsonRoute.php
+++ b/src/routes/BaseJsonRoute.php
@@ -1,8 +1,8 @@
 <?php
-namespace AEFramework\routes;
+namespace AEUtils\routes;
 
-use \AEFramework\models\BaseModel;
-use \AEFramework\JsonResHandler;
+use \AEUtils\models\BaseModel;
+use \AEUtils\JsonResHandler;
 
 class BaseJsonRoute extends BaseRoute {
 

--- a/src/routes/BaseRoute.php
+++ b/src/routes/BaseRoute.php
@@ -1,5 +1,5 @@
 <?php
-namespace AEFramework\routes;
+namespace AEUtils\routes;
 
 use Exception;
 use UnexpectedValueException;

--- a/src/tests/BaseEndpoint.php
+++ b/src/tests/BaseEndpoint.php
@@ -1,5 +1,5 @@
 <?php
-namespace AEFramework\tests;
+namespace AEUtils\tests;
 
 use PDO;
 use Exception;

--- a/src/tests/BaseServiceTest.php
+++ b/src/tests/BaseServiceTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace AEFramework\tests;
+namespace AEUtils\tests;
 
 use PDO;
 use Exception;

--- a/test/AEUtilsTestCase.php
+++ b/test/AEUtilsTestCase.php
@@ -1,5 +1,5 @@
 <?php
-namespace AEFramework\test;
+namespace AEUtils\test;
 use PDO;
 use Exception;
 
@@ -17,7 +17,7 @@ define('TESTMODE', true);
  * - _table_name
  * - _fixture
  */
-abstract class AEFrameworkTestCase extends \PHPUnit_Extensions_Database_TestCase
+abstract class AEUtilsTestCase extends \PHPUnit_Extensions_Database_TestCase
 {
   static private $pdo = null;
   private $conn = null;

--- a/test/TestModel.php
+++ b/test/TestModel.php
@@ -1,7 +1,7 @@
 <?php
-namespace AEFramework\test;
+namespace AEUtils\test;
 
-class TestModel extends \AEFramework\models\BaseModel {
+class TestModel extends \AEUtils\models\BaseModel {
   protected $_json_type = 'test json type';
   protected $_db_table = 'test_table';
   protected $_db_schema = array(

--- a/test/tests/models/BaseModel.php
+++ b/test/tests/models/BaseModel.php
@@ -1,8 +1,8 @@
 <?php
-namespace AEFramework\test;
+namespace AEUtils\test;
 use Exception;
 
-class Model extends \AEFramework\models\BaseModel {
+class Model extends \AEUtils\models\BaseModel {
   protected $_json_type = 'test json type';
   protected $_db_table = 'model_test_table';
   protected $_db_schema = array(
@@ -12,7 +12,7 @@ class Model extends \AEFramework\models\BaseModel {
     'test_attr3' => array(
       'type' => 'string',
       'default' => 'via value',
-      'defaultFunction' => '\AEFramework\test\Model::attr3DefaultFunction'
+      'defaultFunction' => '\AEUtils\test\Model::attr3DefaultFunction'
     ),
     'test_attr4' => array(
       'type' => 'bool',
@@ -31,7 +31,7 @@ class Model extends \AEFramework\models\BaseModel {
   }
 }
 
-class BaseModelTest extends AEFrameworkTestCase
+class BaseModelTest extends AEUtilsTestCase
 {
   protected $_table_name = 'model_test_table';
   protected $_fixture = array(

--- a/test/tests/routes/BaseJsonDeleteRoute.php
+++ b/test/tests/routes/BaseJsonDeleteRoute.php
@@ -1,7 +1,7 @@
 <?php
-namespace AEFramework\test;
+namespace AEUtils\test;
 
-class JsonDeleteRoute extends \AEFramework\routes\BaseJsonDeleteRoute {
+class JsonDeleteRoute extends \AEUtils\routes\BaseJsonDeleteRoute {
   public function __construct()
   {
     $this->_model_object = new TestModel();
@@ -9,7 +9,7 @@ class JsonDeleteRoute extends \AEFramework\routes\BaseJsonDeleteRoute {
   }
 }
 
-class BaseJsonDeleteRouteTest extends AEFrameworkTestCase
+class BaseJsonDeleteRouteTest extends AEUtilsTestCase
 {
   protected $_table_name = 'test_table';
   protected $_fixture = array(

--- a/test/tests/routes/BaseJsonPostRoute.php
+++ b/test/tests/routes/BaseJsonPostRoute.php
@@ -1,7 +1,7 @@
 <?php
-namespace AEFramework\test;
+namespace AEUtils\test;
 
-class JsonPostRoute extends \AEFramework\routes\BaseJsonPostRoute {
+class JsonPostRoute extends \AEUtils\routes\BaseJsonPostRoute {
   public function __construct()
   {
     $this->_model_object = new TestModel();
@@ -9,7 +9,7 @@ class JsonPostRoute extends \AEFramework\routes\BaseJsonPostRoute {
   }
 }
 
-class BaseJsonPostRouteTest extends AEFrameworkTestCase
+class BaseJsonPostRouteTest extends AEUtilsTestCase
 {
   protected $_table_name = 'test_table';
   protected $_fixture = array(

--- a/test/tests/routes/BaseJsonPutRoute.php
+++ b/test/tests/routes/BaseJsonPutRoute.php
@@ -1,7 +1,7 @@
 <?php
-namespace AEFramework\test;
+namespace AEUtils\test;
 
-class JsonPutRoute extends \AEFramework\routes\BaseJsonPutRoute {
+class JsonPutRoute extends \AEUtils\routes\BaseJsonPutRoute {
   public function __construct()
   {
     $this->_model_object = new TestModel();
@@ -9,7 +9,7 @@ class JsonPutRoute extends \AEFramework\routes\BaseJsonPutRoute {
   }
 }
 
-class BaseJsonPutRouteTest extends AEFrameworkTestCase
+class BaseJsonPutRouteTest extends AEUtilsTestCase
 {
   protected $_table_name = 'test_table';
   protected $_fixture = array(

--- a/test/tests/routes/BaseRoute.php
+++ b/test/tests/routes/BaseRoute.php
@@ -1,12 +1,12 @@
 <?php
-namespace AEFramework\test;
+namespace AEUtils\test;
 use Exception;
 
 class BaseRouteTest extends \PHPUnit_Framework_TestCase
 {
   protected function setUp()
   {
-    $this->r = new \AEFramework\routes\BaseRoute();
+    $this->r = new \AEUtils\routes\BaseRoute();
     parent::setUp();
   }
 


### PR DESCRIPTION
This patch brought you by Sed&#8482;. Sed&#8482; can alleviate all your stress by automating household chores and replacing characters in streams of text. Try Sed&#8482; today!

    $ find . -regex '\./\(\.git\|\.vagrant\|vendor\)' -prune -o -type f -print0 | \
        xargs -0 sed -i -e 's/AEFramework/AEUtils/g' -e 's/ae-framework/ae-utils/g'

> The responsibilities of this codebase are changing to fill the role of a
> library rather than a framework. Update the project name in all of its
> occurrences to reflect this change.