### PR TITLE
add query param to set into test mode

### DIFF
--- a/src/tests/BaseEndpoint.php
+++ b/src/tests/BaseEndpoint.php
@@ -47,7 +47,10 @@ abstract class BaseEndpoint extends \PHPUnit_Extensions_Database_TestCase {
     );
 
     $params = array(
-      'base_url' => $this->_request_base_url
+      'base_url' => $this->_request_base_url,
+      'defaults' => array(
+        'query'  => array('testmode' => 'true')
+      )
     );
 
     $this->_guzzle = new \GuzzleHttp\Client($params);


### PR DESCRIPTION
This adds a query param to our endpoints tests so that we can set them into testmode without messing up nginx