### PR TITLE
Fix guzzle options

### DIFF
--- a/src/tests/BaseEndpoint.php
+++ b/src/tests/BaseEndpoint.php
@@ -136,7 +136,13 @@ abstract class BaseEndpoint extends \PHPUnit_Extensions_Database_TestCase {
   protected function _fetch_results($url, $method, $data = null) {
     $options = array();
 
-    if ($data !== null) {
+    if (is_array($data)) {
+      if (!array_key_exists('body', $data)) {
+        $options['body'] = $data;
+      } else {
+        $options = $data;
+      }
+    } else if ($data) {
       $options['body'] = $data;
     }
 


### PR DESCRIPTION
There was an issue with how we were setting up the guzzle request that prevented us from passing other request parameters (besides `body`). This fixes that issue and allows us to specify additional request parameters.